### PR TITLE
Changed the location where the preview HTML file is created

### DIFF
--- a/lib/deliver/html_generator.rb
+++ b/lib/deliver/html_generator.rb
@@ -1,8 +1,8 @@
 module Deliver
   class HtmlGenerator
-    def run(options, screenshots)
+    def run(options, screenshots, export_path)
       begin
-        html_path = self.render(options, screenshots, '.')
+        html_path = self.render(options, screenshots, export_path)
       rescue => ex
         Helper.log.error ex.inspect
         Helper.log.error ex.backtrace.join("\n")
@@ -42,7 +42,7 @@ module Deliver
       html_path = File.join(lib_path, "lib/assets/summary.html.erb")
       html = ERB.new(File.read(html_path)).result(binding) # http://www.rrn.dk/rubys-erb-templating-system
 
-      export_path = File.join(export_path, "Preview.html")
+      export_path = File.join(export_path, "preview.html")
       File.write(export_path, html)
 
       return export_path

--- a/lib/deliver/runner.rb
+++ b/lib/deliver/runner.rb
@@ -46,7 +46,7 @@ module Deliver
       UploadMetadata.new.load_from_filesystem(options)
 
       # Validate
-      validate_html(screenshots)
+      validate_html(options, screenshots)
 
       # Commit
       UploadMetadata.new.upload(options)
@@ -74,9 +74,9 @@ module Deliver
 
     private
 
-    def validate_html(screenshots)
+    def validate_html(options, screenshots)
       return if options[:force]
-      HtmlGenerator.new.run(options, screenshots)
+      HtmlGenerator.new.run(options, screenshots, options[:metadata_path])
     end
   end
 end

--- a/lib/deliver/upload_screenshots.rb
+++ b/lib/deliver/upload_screenshots.rb
@@ -68,7 +68,7 @@ module Deliver
             next
           end
 
-          screenshots << AppScreenshot.new(path, language)
+          screenshots << AppScreenshot.new(File.realpath(path), language)
         end
       end
 


### PR DESCRIPTION
Made sure the path to the screenshots in the array is an absolute path and not relative to the current directory.
Changed the file name of the created preview.html file to lower case.
Changed the location where the preview.html file is generated to the meta data folder.