### PR TITLE
allow use of 'default' language value

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,51 @@ Before actually uploading anything to iTunes, ```deliver``` will generate a HTML
 no, en-US, en-CA, fi, ru, zh-Hans, nl-NL, zh-Hant, en-AU, id, de-DE, sv, ko, ms, pt-BR, el, es-ES, it, fr-CA, es-MX, pt-PT, vi, th, ja, fr-FR, da, tr, en-GB
 ```
 
+## Default values
+
+Deliver has a special language code which allows you to provide values that are not localised, and which will be used as defaults when you don’t provide a specific localised value.
+
+You can use this either in json within your deliverfile, or as a folder in your metadata file.
+
+Imagine that you have localised data for the following language codes:  ```en-US, de-DE, el, it```
+
+You can set the following in your deliverfile
+
+```
+release_notes({
+  'default => "Shiny and new”,
+  'de-DE' => "glänzend und neu"
+})
+```
+
+Deliver will use "Shiny and new" for en-US, el and it.
+
+It will use "glänzend und neu" for de-DE.
+
+You can do the same with folders
+
+```
+   default
+      keywords.txt     
+      marketing_url.txt
+      name.txt
+      privacy_url.txt
+      support_url.txt
+      release_notes.txt
+   en-US
+      description.txt
+   de-DE
+      description.txt
+   el
+      description.txt
+   it
+      description.txt
+```
+
+In this case, default values for keywords, urls, name and release notes are used in all localisations, but each language has a fully localised description
+
+
+
 ## Automatically create screenshots
 
 If you want to integrate `deliver` with [snapshot](https://github.com/fastlane/snapshot), check out [fastlane](https://fastlane.tools)!

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ no, en-US, en-CA, fi, ru, zh-Hans, nl-NL, zh-Hant, en-AU, id, de-DE, sv, ko, ms,
 
 ## Default values
 
-Deliver has a special language code which allows you to provide values that are not localised, and which will be used as defaults when you don’t provide a specific localised value.
+Deliver has a special ```default``` language code which allows you to provide values that are not localised, and which will be used as defaults when you don’t provide a specific localised value.
 
 You can use this either in json within your deliverfile, or as a folder in your metadata file.
 

--- a/lib/deliver/loader.rb
+++ b/lib/deliver/loader.rb
@@ -2,7 +2,7 @@ require 'fastlane_core/languages'
 
 module Deliver
   module Loader
-    ALL_LANGUAGES = FastlaneCore::Languages::ALL_LANGUAGES.map(&:downcase).freeze
+    ALL_LANGUAGES = FastlaneCore::Languages::ALL_LANGUAGES.map(&:downcase).push("default").freeze
 
     def self.language_folders(root)
       Dir.glob(File.join(root, '*')).select do |path|

--- a/lib/deliver/runner.rb
+++ b/lib/deliver/runner.rb
@@ -45,6 +45,7 @@ module Deliver
       # First, collect all the things for the HTML Report
       screenshots = UploadScreenshots.new.collect_screenshots(options)
       UploadMetadata.new.load_from_filesystem(options)
+      UploadMetadata.new.assign_defaults(options)
 
       # Validate
       validate_html(screenshots)

--- a/lib/deliver/upload_metadata.rb
+++ b/lib/deliver/upload_metadata.rb
@@ -61,6 +61,48 @@ module Deliver
       Helper.log.info "Successfully uploaded initial set of metadata to iTunes Connect".green
     end
 
+        # If the user is using the 'default' language, then assign values where they are needed
+    def assign_defaults(options)
+      # Build a complete list of the required languages
+      enabled_languages = []
+
+      # Get all languages used in existing settings
+      (LOCALISED_VERSION_VALUES + LOCALISED_APP_VALUES).each do |key|
+        current = options[key]
+        next unless current && current.kind_of?(Hash)
+        current.each do |language, value|
+          enabled_languages << language unless enabled_languages.include?(language)
+        end
+      end
+
+      # Check folder list (an empty folder signifies a language is required)
+      Dir.glob(File.join(options[:metadata_path], "*")).each do |lng_folder|
+        next unless File.directory?(lng_folder) # We don't want to read txt as they are non localised
+
+        language = File.basename(lng_folder)
+        enabled_languages << language unless enabled_languages.include?(language)
+      end
+
+      return unless enabled_languages.include?("default")
+      Helper.log.info "Detected languages: " + enabled_languages.to_s
+
+      (LOCALISED_VERSION_VALUES + LOCALISED_APP_VALUES).each do |key|
+        current = options[key]
+        next unless current && current.kind_of?(Hash)
+
+        default = current["default"]
+        next if default.nil?
+
+        enabled_languages.each do |language|
+          value = current[language]
+          next unless value.nil?
+
+          current[language] = default
+        end
+        current.delete("default")
+      end
+    end
+
     # Makes sure all languages we need are actually created
     def verify_available_languages!(options)
       return if options[:skip_metadata]


### PR DESCRIPTION
Users can specify a default which applies when there is no specific
value for a given language.

name ({
"en_us" => "English name",
"default" => "Default name"})

will have the same effect as

name ({
"en_us" => "English name",
"fr_FR" => "Default name",
"it" => "Default name",
"ja" => "Default name"})

similarly, a user can create a metadata folder 'default' and put in
something like release_notes.txt
this will be used for all languages where there isn't an explicit
release_notes.txt

languages are filled in if they are either
1) used in a setting explicitly in the deliverfile
2) there is a language folder (possibly empty) in the metadata folder