### PR TITLE
Fix bug with missing close div tag in html preview

### DIFF
--- a/lib/assets/summary.html.erb
+++ b/lib/assets/summary.html.erb
@@ -189,6 +189,11 @@
 
               <% last_size = screenshot.screen_size %>
             <% end %>
+            
+            <% if last_size != nil %>
+              </div>
+            <% end %>
+            
           <% else %>
             <!-- no screenshots -->
             <div style="border: 3px solid red; padding: 0px 20px">


### PR DESCRIPTION
**Symptoms**

When viewing the summary Preview.html generated by deliver, if you had many languages, each language would appear to have more and more padding applied to the width. This meant that languages that were displayed later in the preview would appear in a much narrower column rather than the full width of the screen. It made them hard to read.

Example

1st language 
![screen shot 2015-12-24 at 3 46 30 pm](https://cloud.githubusercontent.com/assets/14914532/11998509/32d53aca-aa57-11e5-8c1f-ed44ba3f683a.png)

14th language
![screen shot 2015-12-24 at 3 47 29 pm](https://cloud.githubusercontent.com/assets/14914532/11998510/39c67f2e-aa57-11e5-8d0e-5910a61f31a9.png)

**Fix**

There was a missing </div> tag at the end of the last row of screenshots per language. This meant that the padding from earlier divs was being reapplied for each subsequent language which led to gradually narrower spacing.

As a precaution, a check was added around the last closing div to make sure that we actually added some screenshots.

14th language with the fix applied
![screen shot 2015-12-24 at 3 48 35 pm](https://cloud.githubusercontent.com/assets/14914532/11998518/7826f262-aa57-11e5-8243-bf4492509f2b.png)

**Tests**

1) > deliver
2) > deliver --skip_metadata
3) > deliver --skip_screenshots
4) > deliver (deleted screenshot directory so no screenshots to process)
5) > deliver (various combinations of number of languages, devices and screenshots per device
6) verified html no longer has missing div tags with an online html validator

**Future suggestions?**

1) choose an online html validator
2) fix up current html to pass chosen validator
3) add a test to check results of chosen html validator