### PR TITLE
* add option for deliver a specific existing build

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,13 @@ To get a list of available options run
 deliver --help
 ```
 
+
+Select a previously uploaded build and submit it for review.
+
+```
+deliver submit_build --build_number 830
+```
+
 Check out [Deliverfile.md](https://github.com/fastlane/deliver/blob/master/Deliverfile.md) for more options.
 
 Already using `deliver` and just updated to 1.0? Check out the [Migration Guide](https://github.com/fastlane/deliver/blob/master/MigrationGuide.md).

--- a/lib/deliver/commands_generator.rb
+++ b/lib/deliver/commands_generator.rb
@@ -49,7 +49,17 @@ module Deliver
           Deliver::Runner.new(options).run
         end
       end
-
+      command :submit_build do |c|
+        c.syntax = 'deliver submit_build'
+        c.description = 'Submit a specific build-nr for review, use latest for the latest build'
+        c.action do |args, options|
+          options = FastlaneCore::Configuration.create(Deliver::Options.available_options, options.__hash__)
+          options.load_configuration_file("Deliverfile")
+          options[:submit_for_review] = true
+          options[:build_number] = "latest" unless options[:build_number]
+          Deliver::Runner.new(options).run
+        end
+      end
       command :init do |c|
         c.syntax = 'deliver init'
         c.description = 'Create the initial `deliver` configuration based on an existing app'

--- a/lib/deliver/options.rb
+++ b/lib/deliver/options.rb
@@ -94,6 +94,15 @@ module Deliver
                                      description: "The price tier of this application",
                                      is_string: false,
                                      optional: true),
+        FastlaneCore::ConfigItem.new(key: :build_number,
+                                     short_option: "-n",
+                                     description: "If set the given build number (already uploaded to iTC) will be used instead of the current built one",
+                                     default_value: "latest",
+                                     optional: true,
+                                     conflicting_options: [:ipa, :pkg],
+                                     conflict_block: proc do |value|
+                                       raise "You can't use 'build_number' and '#{value.key}' options in one run.".red
+                                     end),
         FastlaneCore::ConfigItem.new(key: :app_rating_config_path,
                                      short_option: "-g",
                                      description: "Path to the app rating's config",

--- a/lib/deliver/runner.rb
+++ b/lib/deliver/runner.rb
@@ -20,8 +20,8 @@ module Deliver
       verify_version if options[:app_version].to_s.length > 0
       upload_metadata
 
-      has_binary = options[:ipa] || options[:pkg]
-      if !options[:skip_binary_upload] && has_binary
+      has_binary = (options[:ipa] || options[:pkg])
+      if !options[:skip_binary_upload] && !options[:build_number] && has_binary
         upload_binary
       end
 

--- a/lib/deliver/submit_for_review.rb
+++ b/lib/deliver/submit_for_review.rb
@@ -15,7 +15,6 @@ module Deliver
 
       # User Values
       if options[:submission_information]
-        UI.user_error!("`submission_information` must be a hash") unless options[:submission_information].kind_of?(Hash)
         options[:submission_information].each do |key, value|
           UI.message("Setting '#{key}' to '#{value}'...")
           submission.send("#{key}=", value)
@@ -29,11 +28,19 @@ module Deliver
     end
 
     def select_build(options)
-      UI.message("Selecting the latest build...")
       app = options[:app]
       v = app.edit_version
-      build = wait_for_build(app)
 
+      if options[:build_number] and options[:build_number] != "latest"
+        UI.message("Selecting existing build-number: #{options[:build_number]}")
+        build = v.candidate_builds.detect { |a| a.build_version == options[:build_number] }
+        unless build
+          UI.user_error!("Build number: #{options[:build_number]} does not exist")
+        end
+      else
+        UI.message("Selecting the latest build...")
+        build = wait_for_build(app)
+      end
       UI.message("Selecting build #{build.train_version} (#{build.build_version})...")
 
       v.select_build(build)


### PR DESCRIPTION
allows deliver to select a specific/existing build number instead of uploading current build binary.


sample:

```ruby
deliver(
	build_number: "666",
	force: true,
	skip_metadata: true,
	skip_screenshots: true,
	submit_for_review: true
)
```

to use the latest  (already uploaded build on Tunes) - set `build_number` to `latest`
