### PR TITLE
Update to use latest fastlane_core and add a spec

### DIFF
--- a/deliver.gemspec
+++ b/deliver.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # fastlane dependencies
-  spec.add_dependency 'fastlane_core', '>= 0.36.1', '< 1.0.0' # all shared code and dependencies
+  spec.add_dependency 'fastlane_core', '>= 0.36.4', '< 1.0.0' # all shared code and dependencies
   spec.add_dependency 'credentials_manager', '>= 0.12.0', '< 1.0.0'
   spec.add_dependency 'spaceship', '>= 0.19.0', '<= 1.0.0' # Communication with iTunes Connect
 

--- a/lib/deliver/submit_for_review.rb
+++ b/lib/deliver/submit_for_review.rb
@@ -55,7 +55,7 @@ module Deliver
       start = Time.now
 
       loop do
-        build = find_build(app)
+        build = find_build(app.latest_version.candidate_builds)
         return build if build.processing == false
 
         UI.message("Waiting iTunes Connect processing for build #{build.train_version} (#{build.build_version})... this might take a while...")
@@ -68,16 +68,16 @@ module Deliver
       nil
     end
 
-    def find_build(app)
+    def find_build(candidate_builds)
       build = nil
-      app.latest_version.candidate_builds.each do |b|
+      candidate_builds.each do |b|
         if !build or b.upload_date > build.upload_date
           build = b
         end
       end
 
       unless build
-        UI.error(app.latest_version.candidate_builds)
+        UI.error(candidate_builds)
         UI.crash!("Could not find build")
       end
 

--- a/spec/submit_for_review_spec.rb
+++ b/spec/submit_for_review_spec.rb
@@ -1,0 +1,41 @@
+require 'deliver/submit_for_review'
+require 'active_support/core_ext/numeric/time.rb'
+require 'active_support/core_ext/time/calculations.rb'
+require 'ostruct'
+
+describe Deliver::SubmitForReview do
+  let(:review_submitter) { Deliver::SubmitForReview.new }
+
+  # Create a fake app with number_of_builds candidate builds
+  # the builds will be in date ascending order
+  def make_fake_builds(number_of_builds)
+    (0...number_of_builds).map do |num|
+      OpenStruct.new({ upload_date: num.minutes.from_now })
+    end
+  end
+
+  describe :find_build do
+    context 'one build' do
+      let(:fake_builds) { make_fake_builds(1) }
+      it 'finds the one build' do
+        only_build = fake_builds.first
+        expect(review_submitter.find_build(fake_builds)).to eq(only_build)
+      end
+    end
+
+    context 'no builds' do
+      let(:fake_builds) { make_fake_builds(0) }
+      it 'throws a UI error' do
+        expect { review_submitter.find_build(fake_builds) }.to raise_error FastlaneCore::Interface::FastlaneCrash
+      end
+    end
+
+    context 'two builds' do
+      let(:fake_builds) { make_fake_builds(2) }
+      it 'finds the one build' do
+        newest_build = fake_builds.last
+        expect(review_submitter.find_build(fake_builds)).to eq(newest_build)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/fastlane/deliver/issues/575 by bringing in the new fastlane_core which handles non-string error messages.